### PR TITLE
feat: persist prompt in local storage

### DIFF
--- a/src/lib/pages/book-distiller/index.tsx
+++ b/src/lib/pages/book-distiller/index.tsx
@@ -251,7 +251,9 @@ export default function BookDistiller() {
   const [author, setAuthor] = useState('');
   const [bookText, setBookText] = useState('');
 
-  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [prompt, setPrompt] = useState(
+    () => localStorage.getItem('bd_prompt') || DEFAULT_PROMPT,
+  );
 
   const [provider, setProvider] = useState(
     () => localStorage.getItem('bd_provider') || 'openai',
@@ -299,6 +301,9 @@ export default function BookDistiller() {
   useEffect(() => {
     localStorage.setItem('bd_model', model);
   }, [model]);
+  useEffect(() => {
+    localStorage.setItem('bd_prompt', prompt);
+  }, [prompt]);
 
   const [autoAdvance, setAutoAdvance] = useState(false);
   const [maxSections, setMaxSections] = useState(12);


### PR DESCRIPTION
## Summary
- store prompt in localStorage so it persists like LLM keys

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689913f4ae0c832bb966157c4f6731a3